### PR TITLE
Add option for Mapbox API key

### DIFF
--- a/firefly-iii/DOCS.md
+++ b/firefly-iii/DOCS.md
@@ -88,6 +88,10 @@ Only applies if a remote MYSQL database is used, the password of the above user.
 Only applies if a remote MYSQL database is used, the port that the database
 server is listening on.
 
+### Option: `mapbox_api_key`
+
+Your Mapbox API key for showing a map on the page of a tag.
+
 ## Database usage
 
 By default, Firefly-III will automatically use and configure the Home Assistant

--- a/firefly-iii/config.json
+++ b/firefly-iii/config.json
@@ -21,7 +21,8 @@
   "options": {
     "ssl": false,
     "certfile": "fullchain.pem",
-    "keyfile": "privkey.pem"
+    "keyfile": "privkey.pem",
+    "mapbox_api_key": ""
   },
   "schema": {
     "remote_mysql_host": "str?",
@@ -32,6 +33,7 @@
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
     "certfile": "str",
     "keyfile": "str",
-    "ssl": "bool"
+    "ssl": "bool",
+    "mapbox_api_key": "str"
   }
 }

--- a/firefly-iii/config.json
+++ b/firefly-iii/config.json
@@ -21,8 +21,7 @@
   "options": {
     "ssl": false,
     "certfile": "fullchain.pem",
-    "keyfile": "privkey.pem",
-    "mapbox_api_key": ""
+    "keyfile": "privkey.pem"
   },
   "schema": {
     "remote_mysql_host": "str?",
@@ -34,6 +33,6 @@
     "certfile": "str",
     "keyfile": "str",
     "ssl": "bool",
-    "mapbox_api_key": "str"
+    "mapbox_api_key": "str?"
   }
 }

--- a/firefly-iii/rootfs/etc/services.d/php-fpm/run
+++ b/firefly-iii/rootfs/etc/services.d/php-fpm/run
@@ -4,13 +4,10 @@
 # Runs the PHP-FPM daemon
 # ==============================================================================
 
-CONFIG_PATH=/data/options.json
-
 declare key
 
 key=$(cat /data/firefly/appkey.txt)
 export APP_KEY=${key}
-export MAPBOX_API_KEY=$(jq --raw-output ".mapbox_api_key" $CONFIG_PATH)
 export LOG_CHANNEL=stdout
 export APP_ENV=local
 export DB_CONNECTION=mysql
@@ -19,6 +16,10 @@ export DB_HOST
 export DB_PASSWORD
 export DB_PORT
 export DB_USERNAME
+
+if bashio::config.has_value 'mapbox_api_key';then
+    export MAPBOX_API_KEY=$(bashio::config "mapbox_api_key")
+fi
 
 if bashio::config.has_value 'remote_mysql_host';then
     DB_HOST=$(bashio::config "remote_mysql_host")

--- a/firefly-iii/rootfs/etc/services.d/php-fpm/run
+++ b/firefly-iii/rootfs/etc/services.d/php-fpm/run
@@ -4,10 +4,13 @@
 # Runs the PHP-FPM daemon
 # ==============================================================================
 
+CONFIG_PATH=/data/options.json
+
 declare key
 
 key=$(cat /data/firefly/appkey.txt)
 export APP_KEY=${key}
+export MAPBOX_API_KEY=$(jq --raw-output ".mapbox_api_key" $CONFIG_PATH)
 export LOG_CHANNEL=stdout
 export APP_ENV=local
 export DB_CONNECTION=mysql


### PR DESCRIPTION
# Proposed Changes

This change adds an option to specify the Mapbox API key to enable the map view on a tag's page.

Tested on RPi3B+ 32bit.

## Related Issues

https://github.com/hassio-addons/addon-firefly-iii/issues/8

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/